### PR TITLE
security: add permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/gpgKeys_generation.yml
+++ b/.github/workflows/gpgKeys_generation.yml
@@ -10,7 +10,7 @@ on:
 
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   generate-gpg-keys:

--- a/.github/workflows/gpgKeys_generation.yml
+++ b/.github/workflows/gpgKeys_generation.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
 
+
+permissions:
+  contents: read
+
 jobs:
   generate-gpg-keys:
     runs-on: ubuntu-latest

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -9,7 +9,7 @@ on:
 
 
 permissions:
-  contents: read
+  contents: write
 
 env:
   TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -7,6 +7,10 @@ on:
     tags:
       - '*'
 
+
+permissions:
+  contents: read
+
 env:
   TAG: ${{ github.event.release.tag_name }}
   PGK_VERSION: ${{ github.event.release.tag_name }}

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,6 +8,10 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [push, workflow_dispatch]
 
+
+permissions:
+  contents: read
+
 jobs:
   repolint:
     name: Run Repolinter

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,10 @@ name: Test format
 on:
   push:
 
+
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate format


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to all workflow files missing a permissions block
- Follows the principle of least privilege for GitHub Actions tokens
- Resolves CodeQL alert `actions/missing-workflow-permissions` ([NR-560379](https://new-relic.atlassian.net/browse/NR-560379))

## Test plan
- [ ] Verify CI workflows still pass with the new permissions block
- [ ] Confirm CodeQL alert is resolved after merge

[NR-560379]: https://new-relic.atlassian.net/browse/NR-560379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ